### PR TITLE
Actualización a Astro 5.12 Rama actualiza astro

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,9 @@
 # Agregamos una variable de entorno para solucionar conflictos de dependencias.
 [build.environment]
   NPM_FLAGS = "--legacy-peer-deps"
+
+# Permite que el CDN de imágenes de Netlify procese imágenes de tu CDN de Sanity.
+[images]
+  # Esta es una lista de expresiones regulares.
+  # Este patrón permite cualquier imagen que provenga de https://cdn.sanity.io.
+  remote_images = ["^https://cdn\\.sanity\\.io/.*"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
       "name": "nau-astro-site",
       "version": "0.0.1",
       "dependencies": {
-        "@astrojs/netlify": "^6.5.0",
-        "@astrojs/tailwind": "^5.1.0",
-        "@sanity/astro": "^3.2.8",
+        "@astrojs/netlify": "^6.5.1",
+        "@astrojs/tailwind": "^6.0.2",
+        "@sanity/astro": "^3.2.10",
         "@sanity/client": "^7.6.0",
         "@sanity/image-url": "^1.1.0",
-        "astro": "^5.11.1",
+        "astro": "^5.12.0",
         "astro-portabletext": "^0.11.1",
         "node-fetch": "^3.3.2",
         "nodemailer": "^6.9.14",
@@ -333,9 +333,9 @@
       "license": "MIT"
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.2.tgz",
-      "integrity": "sha512-bO35JbWpVvyKRl7cmSJD822e8YA8ThR/YbUsciWNA7yTcqpIAL2hJDToWP5KcZBWxGT6IOdOkHSXARSNZc4l/Q==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-6.3.3.tgz",
+      "integrity": "sha512-DDRtD1sPvAuA7ms2btc9A7/7DApKqgLMNrE6kh5tmkfy8utD0Z738gqd3p5aViYYdUtHIyEJ1X4mCMxfCfu15w==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.6.1",
@@ -353,7 +353,7 @@
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
         "shiki": "^3.2.1",
-        "smol-toml": "^1.3.1",
+        "smol-toml": "^1.3.4",
         "unified": "^11.0.5",
         "unist-util-remove-position": "^5.0.0",
         "unist-util-visit": "^5.0.0",
@@ -362,16 +362,16 @@
       }
     },
     "node_modules/@astrojs/netlify": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/netlify/-/netlify-6.5.0.tgz",
-      "integrity": "sha512-SWfhKgh69in8GDeZYt/DrDCmF3lm+YxZOYJpiHES2mEHFcGieI83xwkyoLcHBquAGFuJgaIyqrTHu5vH9Af20A==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/netlify/-/netlify-6.5.1.tgz",
+      "integrity": "sha512-zRvYIvrnJ3w3NP1S8sx4PqhcG1XhV/SYuY1XCE8G2CgLCWMguCS6UdB9QfRbYwTVy1fK09tweGq9BCve6CM31A==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/internal-helpers": "0.6.1",
         "@astrojs/underscore-redirects": "1.0.0",
-        "@netlify/blobs": "^10.0.4",
-        "@netlify/functions": "^4.1.10",
-        "@netlify/vite-plugin": "^2.3.7",
+        "@netlify/blobs": "^10.0.5",
+        "@netlify/functions": "^4.1.11",
+        "@netlify/vite-plugin": "^2.4.1",
         "@vercel/nft": "^0.29.2",
         "esbuild": "^0.25.0",
         "tinyglobby": "^0.2.13",
@@ -394,13 +394,13 @@
       }
     },
     "node_modules/@astrojs/tailwind": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-5.1.5.tgz",
-      "integrity": "sha512-1diguZEau7FZ9vIjzE4BwavGdhD3+JkdS8zmibl1ene+EHgIU5hI0NMgRYG3yea+Niaf7cyMwjeWeLvzq/maxg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@astrojs/tailwind/-/tailwind-6.0.2.tgz",
+      "integrity": "sha512-j3mhLNeugZq6A8dMNXVarUa8K6X9AW+QHU9u3lKNrPLMHhOQ0S7VeWhHwEeJFpEK1BTKEUY1U78VQv2gN6hNGg==",
       "license": "MIT",
       "dependencies": {
-        "autoprefixer": "^10.4.20",
-        "postcss": "^8.5.1",
+        "autoprefixer": "^10.4.21",
+        "postcss": "^8.5.3",
         "postcss-load-config": "^4.0.2"
       },
       "peerDependencies": {
@@ -3996,12 +3996,12 @@
       "license": "Apache 2"
     },
     "node_modules/@netlify/blobs": {
-      "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.0.4.tgz",
-      "integrity": "sha512-eQghoBRI11PxlwtoEhCUS1+BZTLClX/SyxzgAWjTIKSv+qYSdT0T9p4EktbspSEqhZCDROtlRPY5mszuTeSvYw==",
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.0.6.tgz",
+      "integrity": "sha512-KP3jSg+ipILXSXq0CfKlMzNNZtJpvkSuDF2A4F0s6w8nSyl+0UrOid9VaFdyrVvSiwBZOEE6eF6qvNqfQKYKnA==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/dev-utils": "3.2.2",
+        "@netlify/dev-utils": "4.0.0",
         "@netlify/runtime-utils": "2.1.0"
       },
       "engines": {
@@ -4009,9 +4009,9 @@
       }
     },
     "node_modules/@netlify/cache": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@netlify/cache/-/cache-3.0.5.tgz",
-      "integrity": "sha512-59GNOCVfQlOfvNPCQ3SF014NRBweVhP5eDrqSzfzVAGANmEcrRKcU59fTCZx6SUtuuLy6ndewGC/oWX0rfFZ6w==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@netlify/cache/-/cache-3.0.7.tgz",
+      "integrity": "sha512-rbB/XDJMRaReqV3cMV6nQ6KG4YoCDXBtf6O0nNykdRm82rtjTjwuLS8v5ANR6Bir7NPx0zgARn2f5AIr+6EcPg==",
       "license": "MIT",
       "dependencies": {
         "@netlify/runtime-utils": "2.1.0"
@@ -4059,21 +4059,21 @@
       }
     },
     "node_modules/@netlify/dev": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/@netlify/dev/-/dev-4.3.8.tgz",
-      "integrity": "sha512-iccnf6TOf/fko2tIOF/HKAUsOAEcGRBCRqcOAgja6VY4EuF2kfI2CLextzNOW6qoYbnaxSz0C0oQYYXDEEijMw==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@netlify/dev/-/dev-4.4.3.tgz",
+      "integrity": "sha512-8z8Yp4gP9q/ePzRYjGhe9uyCoeLI2XsJDK7pNWbVULt9HcOCwTi9q8Xnj3m5USlkb+AI8YHdoI5SCrR1UZHzQg==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/blobs": "10.0.4",
-        "@netlify/config": "^23.0.11",
-        "@netlify/dev-utils": "3.2.2",
-        "@netlify/edge-functions": "2.15.6",
-        "@netlify/functions": "4.1.10",
-        "@netlify/headers": "2.0.4",
-        "@netlify/images": "1.1.2",
-        "@netlify/redirects": "3.0.4",
-        "@netlify/runtime": "4.0.8",
-        "@netlify/static": "3.0.4",
+        "@netlify/blobs": "10.0.6",
+        "@netlify/config": "^23.2.0",
+        "@netlify/dev-utils": "4.0.0",
+        "@netlify/edge-functions": "2.16.0",
+        "@netlify/functions": "4.1.12",
+        "@netlify/headers": "2.0.6",
+        "@netlify/images": "1.2.2",
+        "@netlify/redirects": "3.0.6",
+        "@netlify/runtime": "4.0.10",
+        "@netlify/static": "3.0.6",
         "ulid": "^3.0.0"
       },
       "engines": {
@@ -4081,9 +4081,9 @@
       }
     },
     "node_modules/@netlify/dev-utils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-3.2.2.tgz",
-      "integrity": "sha512-ECz/xEaqhAPUoFkeC2Ofpky1HBEKwPCsAL66iK/dLFHUFs39SC3y6Bn5QY76DzONmt+RjWmoYkSIEhJ1xAWHfA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.0.0.tgz",
+      "integrity": "sha512-WJlP9/2eo3Ij7rNLWrZun8djeoT04DC6Np0xWrzSUAytGgdgCUDAXXK5x0g8GKwSXD7cPT1oMTUvgflBHoECzw==",
       "license": "MIT",
       "dependencies": {
         "@whatwg-node/server": "^0.10.0",
@@ -4139,13 +4139,13 @@
       }
     },
     "node_modules/@netlify/edge-functions": {
-      "version": "2.15.6",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.15.6.tgz",
-      "integrity": "sha512-lVPi0ZUNLEMo4Q/EbWWsa+1Q3EAEzaZ0F1oGtw3k5tctGZ13kJ0go/zs98reErCFNec/0lC8dqcbZn4WDAqzNg==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-functions/-/edge-functions-2.16.0.tgz",
+      "integrity": "sha512-y/Y/DtS0Z+JDmVzZ00SG6Qqiu9UOSZUEz3wXktzKLmhHO7yKy/PePITwJBZ13HtGEnetKioE/62ScevLVoHX8w==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/dev-utils": "3.2.2",
-        "@netlify/edge-bundler": "^14.0.6",
+        "@netlify/dev-utils": "4.0.0",
+        "@netlify/edge-bundler": "^14.2.2",
         "@netlify/edge-functions-bootstrap": "^2.14.0",
         "@netlify/runtime-utils": "2.1.0",
         "@netlify/types": "2.0.2",
@@ -4162,15 +4162,15 @@
       "license": "MIT"
     },
     "node_modules/@netlify/functions": {
-      "version": "4.1.10",
-      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-4.1.10.tgz",
-      "integrity": "sha512-qAu2rTtVROK46NOHULIMTJRuAy38ezJIjgN1Qanr6Rrp/tHAg/q//OZdOzN/x2wyYO8WzQiHKwU9SjgEjbot6w==",
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@netlify/functions/-/functions-4.1.12.tgz",
+      "integrity": "sha512-btkG/IAvAFdQ8mmw07a+q3fgiPbPq3rKcjsmyS7qaEZDGXnI436MyMq/U5ZNhxNyM9zuiUGuF/gDvN+SS+K5Jw==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/blobs": "10.0.4",
-        "@netlify/dev-utils": "3.2.2",
+        "@netlify/blobs": "10.0.6",
+        "@netlify/dev-utils": "4.0.0",
         "@netlify/serverless-functions-api": "2.1.3",
-        "@netlify/zip-it-and-ship-it": "^12.2.0",
+        "@netlify/zip-it-and-ship-it": "^12.2.1",
         "cron-parser": "^4.9.0",
         "decache": "^4.6.2",
         "extract-zip": "^2.0.1",
@@ -4185,9 +4185,9 @@
       }
     },
     "node_modules/@netlify/headers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@netlify/headers/-/headers-2.0.4.tgz",
-      "integrity": "sha512-ImcYYPtZ0kUM3p+ySYr+8u5Pz+j2oso5v/u55EzWi48XicbTmjsmMpDZ9uOzN2FDFwlKdpWbRGifefp3h3hIpw==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@netlify/headers/-/headers-2.0.6.tgz",
+      "integrity": "sha512-cXPKQL0HknLLOhhSWTvtvioJi3PoSNyrotk+2QOLohydirL4KyM3fKstxQcpOzbuNqjjkUXHwDn6mt4nNOqYwA==",
       "license": "MIT",
       "dependencies": {
         "@netlify/headers-parser": "^9.0.1"
@@ -4214,9 +4214,9 @@
       }
     },
     "node_modules/@netlify/images": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@netlify/images/-/images-1.1.2.tgz",
-      "integrity": "sha512-xhjv74xQT3rbQM195zV5wEWYGASasGSHnuK9rCDjuoOiZpxzD3ua8s+A0y2TWTa3yRVj3dqbBPDICM/yxEq/vA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@netlify/images/-/images-1.2.2.tgz",
+      "integrity": "sha512-1CaTqP/fQ6xuKah8+OZ966JYz6kTyY89UgTUrbEHnHmCBNUVcP7fF2jFbcB55ltF7iH/PANTSoM1aghH84x7bg==",
       "license": "MIT",
       "dependencies": {
         "ipx": "^3.0.3"
@@ -4251,9 +4251,9 @@
       }
     },
     "node_modules/@netlify/redirects": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@netlify/redirects/-/redirects-3.0.4.tgz",
-      "integrity": "sha512-RS7P6tWKr/T03S2IwB4XcskhPNBX66bRbuFl6UNUNuE/aV/yYcI4uiH3x+0HUpVuI2rbMx4U0wAAM7aPQaiLTA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@netlify/redirects/-/redirects-3.0.6.tgz",
+      "integrity": "sha512-9WnSC/1Qy+FKfOGYy8ETDdt+yTMQGISY9qZazqYTkNARZc/UUB40umqCVxdwt4h80uHNAI1BYV91+/PWoiCNWQ==",
       "license": "MIT",
       "dependencies": {
         "@netlify/redirect-parser": "^15.0.2",
@@ -4266,13 +4266,13 @@
       }
     },
     "node_modules/@netlify/runtime": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@netlify/runtime/-/runtime-4.0.8.tgz",
-      "integrity": "sha512-9Rg+7/dMDAve+S9CSx55afu0k/N2/9P5c9wB3ZZ0LbUwvwTLthmY5jktGu93gglHLmBIPzd29752azjxqWMAIg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@netlify/runtime/-/runtime-4.0.10.tgz",
+      "integrity": "sha512-Gx6SraSkzDhj5HBFSXJ4A2ZZJE8xVZq2XXNDBTm5i5wxNeuJ53sYD84rPzNmLU7E+kQwXaBH+2ezod4zeV0y5Q==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/blobs": "^10.0.4",
-        "@netlify/cache": "3.0.5",
+        "@netlify/blobs": "^10.0.6",
+        "@netlify/cache": "3.0.7",
         "@netlify/runtime-utils": "2.1.0",
         "@netlify/types": "2.0.2"
       },
@@ -4299,9 +4299,9 @@
       }
     },
     "node_modules/@netlify/static": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@netlify/static/-/static-3.0.4.tgz",
-      "integrity": "sha512-eI86xTZHyjwkpqTlLi+9GHtvc4xkFao4OquHZGI4CsJ5HhjVxkA9G6hu/Otzod/SDW4JJlBEO0CnK9wI9cZPHA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@netlify/static/-/static-3.0.6.tgz",
+      "integrity": "sha512-K2rT87dygIKt9KkY+eWL7CYTNlB9ia4GxOKmjy/Qh6vA5WAT9xpa/SsTZ7Zja4voEWejbu1Wiy/1mV2cL1tqtA==",
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0"
@@ -4320,13 +4320,13 @@
       }
     },
     "node_modules/@netlify/vite-plugin": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@netlify/vite-plugin/-/vite-plugin-2.3.9.tgz",
-      "integrity": "sha512-Pwl1JGlrBx1tGvO0EZ4tLx4fpoHaGXd1tImF8G7MmbvZFNm3LdZYX+IcdKEA5I/h83+WvtGWLisKzUHakrZyOA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@netlify/vite-plugin/-/vite-plugin-2.4.3.tgz",
+      "integrity": "sha512-gSUA5YjGh8Hdo34xW93YDRwd4pO62AErNEimMQcQvpdaUtIU5nsESlzDDfnbxMPtcaDiLyOggpOewkG6LSs9xQ==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/dev": "4.3.8",
-        "@netlify/dev-utils": "^3.2.2",
+        "@netlify/dev": "4.4.3",
+        "@netlify/dev-utils": "^4.0.0",
         "chalk": "^5.4.1"
       },
       "engines": {
@@ -6093,12 +6093,12 @@
       }
     },
     "node_modules/@sanity/astro": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@sanity/astro/-/astro-3.2.8.tgz",
-      "integrity": "sha512-S96EJmXnOeGlCdMQg9x0eYmioEAMSGszBmKi9UCcGKzXkjW1UGsnK/OSfhGqNHQgKLjfCVjrVpyAbLLIoVeaLA==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@sanity/astro/-/astro-3.2.10.tgz",
+      "integrity": "sha512-f/T4VWlJjyg7/t6RZsvTjQ11zaubOa1cmQoBSstEhNrHQBDQ1HFipGCyFtigZ6w4INUUj7L2/k4gmxdNzt4wjg==",
       "license": "MIT",
       "dependencies": {
-        "@sanity/visual-editing": "^2.14.0",
+        "@sanity/visual-editing": "^2.15.2",
         "history": "^5.3.0"
       },
       "engines": {
@@ -6110,8 +6110,8 @@
         "react": "^18.2.0 || ^19.0.0",
         "react-dom": "^18.2.0 || ^19.0.0",
         "react-is": "^18.2.0 || ^19.0.0",
-        "sanity": "^3.90.0",
-        "styled-components": "^6.1.18"
+        "sanity": "^3.99.0 || ^4.0.0",
+        "styled-components": "^6.1.19"
       }
     },
     "node_modules/@sanity/bifur-client": {
@@ -7441,60 +7441,60 @@
       }
     },
     "node_modules/@shikijs/core": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.8.0.tgz",
-      "integrity": "sha512-gWt8NNZFurL6FMESO4lEsmspDh0H1fyUibhx1NnEH/S3kOXgYiWa6ZFqy+dcjBLhZqCXsepuUaL1QFXk6PrpsQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-uTSXzUBQ/IgFcUa6gmGShCHr4tMdR3pxUiiWKDm8pd42UKJdYhkAYsAmHX5mTwybQ5VyGDgTjW4qKSsRvGSang==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.8.0",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
       }
     },
     "node_modules/@shikijs/engine-javascript": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.8.0.tgz",
-      "integrity": "sha512-IBULFFpQ1N5Cg/C7jPCGnjIKz72CcRtD0BIbNhSuXPUOxLG0bF1URsP/uLfxQFQ9ORfunCQwL7UuSX1RSRBwUQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-3.8.1.tgz",
+      "integrity": "sha512-rZRp3BM1llrHkuBPAdYAzjlF7OqlM0rm/7EWASeCcY7cRYZIrOnGIHE9qsLz5TCjGefxBFnwgIECzBs2vmOyKA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.8.0",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.3"
       }
     },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.8.0.tgz",
-      "integrity": "sha512-Tx7kR0oFzqa+rY7t80LjN8ZVtHO3a4+33EUnBVx2qYP3fGxoI9H0bvnln5ySelz9SIUTsS0/Qn+9dg5zcUMsUw==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.8.1.tgz",
+      "integrity": "sha512-KGQJZHlNY7c656qPFEQpIoqOuC4LrxjyNndRdzk5WKB/Ie87+NJCF1xo9KkOUxwxylk7rT6nhlZyTGTC4fCe1g==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.8.0",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.8.0.tgz",
-      "integrity": "sha512-mfGYuUgjQ5GgXinB5spjGlBVhG2crKRpKkfADlp8r9k/XvZhtNXxyOToSnCEnF0QNiZnJjlt5MmU9PmhRdwAbg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.8.1.tgz",
+      "integrity": "sha512-TjOFg2Wp1w07oKnXjs0AUMb4kJvujML+fJ1C5cmEj45lhjbUXtziT1x2bPQb9Db6kmPhkG5NI2tgYW1/DzhUuQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.8.0"
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.8.0.tgz",
-      "integrity": "sha512-yaZiLuyO23sXe16JFU76KyUMTZCJi4EMQKIrdQt7okoTzI4yAaJhVXT2Uy4k8yBIEFRiia5dtD7gC1t8m6y3oQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.8.1.tgz",
+      "integrity": "sha512-Vu3t3BBLifc0GB0UPg2Pox1naTemrrvyZv2lkiSw3QayVV60me1ujFQwPZGgUTmwXl1yhCPW8Lieesm0CYruLQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "3.8.0"
+        "@shikijs/types": "3.8.1"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.8.0.tgz",
-      "integrity": "sha512-I/b/aNg0rP+kznVDo7s3UK8jMcqEGTtoPDdQ+JlQ2bcJIyu/e2iRvl42GLIDMK03/W1YOHOuhlhQ7aM+XbKUeg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-5C39Q8/8r1I26suLh+5TPk1DTrbY/kn3IdWA5HdizR0FhlhD05zx5nKCqhzSfDHH3p4S0ZefxWd77DLV+8FhGg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -8129,12 +8129,12 @@
       }
     },
     "node_modules/@whatwg-node/fetch": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.8.tgz",
-      "integrity": "sha512-Rw9z3ctmeEj8QIB9MavkNJqekiu9usBCSMZa+uuAvM0lF3v70oQVCXNppMIqaV6OTZbdaHF1M2HLow58DEw+wg==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.10.9.tgz",
+      "integrity": "sha512-2TaXKmjy53cybNtaAtzbPOzwIPkjXbzvZcimnaJxQwYXKSC8iYnWoZOyT4+CFt8w0KDieg5J5dIMNzUrW/UZ5g==",
       "license": "MIT",
       "dependencies": {
-        "@whatwg-node/node-fetch": "^0.7.21",
+        "@whatwg-node/node-fetch": "^0.7.22",
         "urlpattern-polyfill": "^10.0.0"
       },
       "engines": {
@@ -8148,9 +8148,9 @@
       "license": "MIT"
     },
     "node_modules/@whatwg-node/node-fetch": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.21.tgz",
-      "integrity": "sha512-QC16IdsEyIW7kZd77aodrMO7zAoDyyqRCTLg+qG4wqtP4JV9AA+p7/lgqMdD29XyiYdVvIdFrfI9yh7B1QvRvw==",
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.7.22.tgz",
+      "integrity": "sha512-h4GGjGF2vH3kGJ/fEOeg9Xfu4ncoyRwFcjGIxr/5dTBgZNVwq888byIsZ+XXRDJnNnRlzVVVQDcqrZpY2yctGA==",
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^3.1.1",
@@ -8566,14 +8566,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "5.11.1",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-5.11.1.tgz",
-      "integrity": "sha512-32dpUh0tXSV/FR2q2/z7LOA6IXl7RqET9J51IA0pPSSi3exhRP3EOSQGjBq10DzXT7VrvplDrFqwfiiWBS8oYA==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-5.12.0.tgz",
+      "integrity": "sha512-Oov5JsMFHuUmuO+Nx6plfv3nQNK1Xl/8CgLvR8lBhZTjYnraxhuPX5COVAzbom+YLgwaDfK7KBd8zOEopRf9mg==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^2.12.2",
         "@astrojs/internal-helpers": "0.6.1",
-        "@astrojs/markdown-remark": "6.3.2",
+        "@astrojs/markdown-remark": "6.3.3",
         "@astrojs/telemetry": "3.3.0",
         "@capsizecss/unpack": "^2.4.0",
         "@oslojs/encoding": "^1.1.0",
@@ -8616,6 +8616,7 @@
         "rehype": "^13.0.2",
         "semver": "^7.7.1",
         "shiki": "^3.2.1",
+        "smol-toml": "^1.3.4",
         "tinyexec": "^0.3.2",
         "tinyglobby": "^0.2.12",
         "tsconfck": "^3.1.5",
@@ -19900,17 +19901,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.8.0.tgz",
-      "integrity": "sha512-yPqK0y68t20aakv+3aMTpUMJZd6UHaBY2/SBUDowh9M70gVUwqT0bf7Kz5CWG0AXfHtFvXCHhBBHVAzdp0ILoQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-3.8.1.tgz",
+      "integrity": "sha512-+MYIyjwGPCaegbpBeFN9+oOifI8CKiKG3awI/6h3JeT85c//H2wDW/xCJEGuQ5jPqtbboKNqNy+JyX9PYpGwNg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "3.8.0",
-        "@shikijs/engine-javascript": "3.8.0",
-        "@shikijs/engine-oniguruma": "3.8.0",
-        "@shikijs/langs": "3.8.0",
-        "@shikijs/themes": "3.8.0",
-        "@shikijs/types": "3.8.0",
+        "@shikijs/core": "3.8.1",
+        "@shikijs/engine-javascript": "3.8.1",
+        "@shikijs/engine-oniguruma": "3.8.1",
+        "@shikijs/langs": "3.8.1",
+        "@shikijs/themes": "3.8.1",
+        "@shikijs/types": "3.8.1",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/netlify": "^6.5.0",
-    "@astrojs/tailwind": "^5.1.0",
-    "@sanity/astro": "^3.2.8",
+    "@astrojs/netlify": "^6.5.1",
+    "@astrojs/tailwind": "^6.0.2",
+    "@sanity/astro": "^3.2.10",
     "@sanity/client": "^7.6.0",
     "@sanity/image-url": "^1.1.0",
-    "astro": "^5.11.1",
+    "astro": "^5.12.0",
     "astro-portabletext": "^0.11.1",
     "node-fetch": "^3.3.2",
     "nodemailer": "^6.9.14",

--- a/src/components/ContactForm.astro
+++ b/src/components/ContactForm.astro
@@ -1,8 +1,9 @@
 ---
 // src/components/ContactForm.astro
 
-// La clave pública de reCAPTCHA v3 es segura para exponer en el frontend.
-const recaptchaSiteKey = '6Lcy43grAAAAAPTd99MJiK7E42tofYVIbLD8sXgQ';
+// Leemos la clave pública de reCAPTCHA desde las variables de entorno.
+// Astro pone a disposición las variables con prefijo PUBLIC_ a través de import.meta.env.
+const recaptchaSiteKey = import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY;
 ---
 
 <!-- Formulario gestionado por el script de abajo -->


### PR DESCRIPTION
Se creó la rama actualiza-astro y en ella se actualizó a Astro 5.12 para cuidar el sitio en la rama desarrollo. Cuando se garantice que no hay rupturas con la actualización se fusionarán y se seguirá el desarrollo en la rama desarrollo